### PR TITLE
cancel threads instead of waiting for join

### DIFF
--- a/server2.c
+++ b/server2.c
@@ -468,9 +468,9 @@ int main(int argc, char *argv[])
     //read_thread(&rinfo);
 
 
-    pthread_join(r_thread, NULL);
+    pthread_cancel(r_thread);
     for (i = 0; i < pub->nb_threads; i++) {
-        pthread_join(w_threads[i], NULL);
+        pthread_cancel(w_threads[i]);
     }
 
     publisher_free(pub);


### PR DESCRIPTION
currently, whenever an error about the port being in use or being unable to setup the server comes out of `accept_thread(&ainfo);`, the server will still merrily go along and let all the threads run indefinitely until I manually ^C it. with `pthread_cancel` instead of `pthread_join` they get canceled and it can actually exit if `accept_thread(&ainfo);` were to return prematurely.